### PR TITLE
Issue 2530: Increase PHP memory limit to 4096M

### DIFF
--- a/scripts/install_matomo
+++ b/scripts/install_matomo
@@ -178,7 +178,7 @@ function main() {
   # Values required to run report on 12 months of data.
   php::update_config_file \
     "memory_limit" \
-    "2048M" \
+    "4096M" \
     "${APACHE2_PHP_INI_FILE_PATH}"
   php::update_config_file \
     "max_execution_time" \


### PR DESCRIPTION
- Incrased the PHP allowed memory to 4096M to fix some heatmap reports errors.